### PR TITLE
added invert tailwind class into the footer logo

### DIFF
--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -2,7 +2,7 @@
     <div class="md:flex md:justify-between">
         <div class="mb-6 md:mb-0">
             <a href="/" class="flex items-center">
-                <img src="images/logo.svg" class="h-12 mr-3" alt="FlowBite Logo"/>
+                <img src="images/logo.svg" class="h-12 mr-3 invert" alt="FlowBite Logo"/>
             </a>
         </div>
         <div class="grid grid-cols-2 gap-8 sm:gap-6 sm:grid-cols-2">


### PR DESCRIPTION
fixes #7 
Added the _invert_ tailwind class to the footer.ejs logo. Now logo is visible.
![image](https://github.com/subhashis2204/project-annapurna/assets/107319136/5a604113-9b70-4468-bd11-e19731e1bd93)
