### PR TITLE
Added invert property for footer logo for dark theme

### DIFF
--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -2,7 +2,7 @@
     <div class="md:flex md:justify-between">
         <div class="mb-6 md:mb-0">
             <a href="/" class="flex items-center">
-                <img src="images/logo.svg" class="h-12 mr-3" alt="FlowBite Logo"/>
+                <img src="images/logo.svg" class="h-12 mr-3 dark:invert" alt="FlowBite Logo"/>
             </a>
         </div>
         <div class="grid grid-cols-2 gap-8 sm:gap-6 sm:grid-cols-2">


### PR DESCRIPTION
Apologies for my previous pull request where I did not consider the property for the light theme. I have now added the 'dark:invert' class from Tailwind CSS specifically to the footer logo, ensuring that it is inverted only in the dark theme.

Below is footer logo in dark and light theme:
![1](https://github.com/subhashis2204/project-annapurna/assets/107319136/605faf94-9598-4505-bf83-f564b46bd4c5)
![2](https://github.com/subhashis2204/project-annapurna/assets/107319136/1a097fab-baa7-403d-8313-815de601bb34)
